### PR TITLE
Use number of passed arguments to trigger overload

### DIFF
--- a/src/hidden-state.js
+++ b/src/hidden-state.js
@@ -1,14 +1,16 @@
 const WM = WeakMap;
 
-const [$get, $set] = ['get', 'set'].map(
+const [$get, $set, $has] = ['get', 'set', 'has'].map(
   name => Function.prototype.call.bind(WM.prototype[name])
 );
 
 export default function hiddenState(description = '') {
   const map = new WM();
 
-  function hidden(obj, data) {
-    if (data !== undefined) {
+  function hidden(obj, ...args) {
+    let data;
+    if (args.length > 0) {
+      data = args[0];
       $set(map, obj, data);
     } else {
       data = $get(map, obj);
@@ -21,7 +23,7 @@ export default function hiddenState(description = '') {
     return data;
   }
 
-  hidden.hasState = (obj => $get(map, obj) !== undefined);
+  hidden.hasState = (obj => $has(map, obj));
 
   return hidden;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -49,6 +49,13 @@ import * as assert from 'assert';
 }
 
 {
+  let hidden = hiddenState();
+  let obj = {};
+  hidden(obj, undefined);
+  assert.equal(hidden.hasState(obj), true);
+}
+
+{
   const hidden = hiddenState('Point');
 
   class Point {
@@ -92,10 +99,12 @@ import * as assert from 'assert';
   // This test patches globals - it should be executed last
   WeakMap.prototype.get = function() { throw new Error(); };
   WeakMap.prototype.get = function() { throw new Error(); };
+  WeakMap.prototype.has = function() { throw new Error(); };
   global.WeakMap = function() {};
 
   let hidden = hiddenState();
   let obj = {};
   hidden(obj, { x: 1, y: 2 });
   assert.deepEqual(hidden(obj), { x: 1, y: 2 });
+  assert.deepEqual(hidden.hasState(obj), true);
 }


### PR DESCRIPTION
Fixes #2 

I was worried about performance of using a rest arg but it seems to be comparable when testing on Node.